### PR TITLE
Add flux dockerfile

### DIFF
--- a/.github/workflows/ci_rp.yml
+++ b/.github/workflows/ci_rp.yml
@@ -16,8 +16,9 @@ jobs:
       run: |
         docker build -t base docker/base
         docker build -t rp   docker/rp
+        docker build -t flux docker/flux
 
     - name: Run tests
       run: |
-        docker run rp
+        docker run rp && docker run flux
 

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,8 +1,10 @@
 FROM centos:7
 
 RUN yum -y update \
+ && yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+ && yum -y update \
  && yum -y install \
-    # General & Flux Dependencies
+    # General & Flux-core Dependencies
     which \
     sudo \
     git \
@@ -40,13 +42,23 @@ RUN yum -y update \
     man-db \
     lz4-devel \
     jq \
+    # Flux-sched dependencies
+    libboost-graph-devel \
+    libboost-system-devel \
+    libboost-filesystem-devel \
+    libboost-regex-devel \
+    libxml2-devel \
+    readline-devel \
+    yaml-cpp-devel \
     # Swift/T Deps
     java-1.7.0-openjdk-headless \
     java-1.7.0-openjdk-devel \
     tcl \
  && yum clean all
 
+# Swift/T Dependency on Apache Ant
 RUN wget https://apache.claz.org//ant/binaries/apache-ant-1.9.15-bin.tar.gz \
     && tar xvf apache-ant-1.9.15-bin.tar.gz -C /opt \
     && ln -s /opt/apache-ant-1.9.15 /opt/ant \
     && sudo ln -s /opt/ant/bin/ant /usr/bin/ant
+

--- a/docker/flux/Dockerfile
+++ b/docker/flux/Dockerfile
@@ -1,0 +1,35 @@
+FROM exaworks/sdk-base
+
+ARG FLUX_CORE_VERSION=0.24.0
+ARG FLUX_SCHED_VERSION=0.15.0
+
+# Install Flux-core from release tarball
+RUN V=$FLUX_CORE_VERSION \
+   && PKG=flux-core-$V \
+   && URL=https://github.com/flux-framework/flux-core/releases/download \
+   && wget ${URL}/v${V}/${PKG}.tar.gz \
+   && tar xvf ${PKG}.tar.gz \
+   && cd ${PKG} \
+   && ./configure --prefix=/usr \
+   && make -j 4 \
+   && make install \
+   && cd .. \
+   && rm -rf flux-core-* \
+   && ldconfig
+
+# Install Flux-sched from release tarball
+RUN V=$FLUX_SCHED_VERSION \
+   && PKG=flux-sched-$V \
+   && URL=https://github.com/flux-framework/flux-sched/releases/download \
+   && wget ${URL}/v${V}/${PKG}.tar.gz \
+   && tar xvf ${PKG}.tar.gz \
+   && cd ${PKG} \
+   && ./configure --prefix=/usr \
+   && make -j 4 \
+   && make install \
+   && cd .. \
+   && rm -rf flux-sched-* \
+   && ldconfig
+
+COPY test.sh /
+CMD /test.sh

--- a/docker/flux/test.sh
+++ b/docker/flux/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+output=$(flux start flux mini run echo Success)
+if [[ "$output" != "Success" ]]; then
+    exit 1
+fi
+
+echo "All tests ran successfully!"


### PR DESCRIPTION
Builds on top of #16.  It was only after trying to compile Flux that I realized the `python36-cffi` package is only in EPEL.  So this PR adds EPEL before installing all of the dependency packages.  Otherwise, the previous `RUN` commands from #16 should be the same.

This PR ensures that flux is built correctly by running `make check` as part of the image build.  It also adds a small test.sh that ensures flux starts and can run a simple single-core job.

While the Dockerfile is technically parameterized to support different versions of flux-core, I only tested that the latest release (0.24.0) builds and runs successfully.

Closes #4