### PR TITLE
ci: simplify deploy workflow action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,6 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         context: ./docker/base
-        file: ./Dockerfile
         push: true
         tags: |
           exaworks/sdk-base:latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,14 +28,6 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-buildx-
-
     - name: Build and push
       id: docker_build
       uses: docker/build-push-action@v2
@@ -47,13 +39,3 @@ jobs:
           exaworks/sdk-base:latest
           ghcr.io/exaworks/sdk-base:latest
         platforms: linux/amd64
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache-new        
-
-    - # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      name: Move cache
-      run: |
-        rm -rf /tmp/.buildx-cache
-        mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
Cleanup the deploy workflow to be more debuggable and maintainable (drop lots of fancy, unnecessary caching).
Fix the broken dockerfile path reference.