### PR TITLE
CI: deploy combined image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,7 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Build and push
+    - name: Build and push base image
       id: docker_build
       uses: docker/build-push-action@v2
       with:
@@ -38,3 +38,11 @@ jobs:
           exaworks/sdk-base:latest
           ghcr.io/exaworks/sdk-base:latest
         platforms: linux/amd64
+
+    - name: Build and push composite image
+      run: |
+        docker build -t rp docker/rp
+        docker build -t rp_parsl --build-arg BASE_IMAGE=rp docker/Parsl
+        docker build -t rp_parsl_swift --build-arg BASE_IMAGE=rp_parsl docker/swift-t
+        docker build -t exaworks/sdk --build-arg BASE_IMAGE=rp_parsl_swift docker/flux
+        docker push exaworks/sdk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,6 @@ jobs:
         push: true
         tags: |
           exaworks/sdk-base:latest
-          ghcr.io/exaworks/sdk-base:latest
         platforms: linux/amd64
 
     - name: Build and push composite image


### PR DESCRIPTION
Setup the deploy workflow to build the 4 components into a single image a deploy to docker hub.  Useful for testing the psi-j-python repo (among other things).

I went ahead and deployed the image as `exaworks/sdk`.  Thoughts on the name?

Closes #47 