### PR TITLE
ci: switch to using an exaworks-specific validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0
     - run: git fetch origin master
-    - uses: flux-framework/pr-validator@master
+    - uses: exaworks/pr-validator@master


### PR DESCRIPTION
Problem: the flux validator does not allow merge commits which puts the
PR into a deadlock when the merge fallback action is applied by mergify