### PR TITLE
base: switch to using apache archive for ant

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -77,7 +77,7 @@ RUN yum -y update \
  && pip install "cryptography==3.3.2"
 
 # Swift/T Dependency on Apache Ant
-RUN wget https://apache.claz.org//ant/binaries/apache-ant-1.9.15-bin.tar.gz \
+RUN wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.15-bin.tar.gz \
     && tar xvf apache-ant-1.9.15-bin.tar.gz -C /opt \
     && ln -s /opt/apache-ant-1.9.15 /opt/ant \
     && sudo ln -s /opt/ant/bin/ant /usr/bin/ant


### PR DESCRIPTION
Problem: whenever a new patch version of ant is released, they remove the old versions from the mirrors.

Solution: Use the archive so that we can reliably pull our pinned version of ant.