### PR TITLE
CI: Fix deploy of the `latest` tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,5 +67,7 @@ jobs:
     - name: Push images with 'latest' tag
       if: ${{ matrix.dockerbase == 'centos7' }}
       run: |
+        docker tag exaworks/sdk-base:${{ matrix.dockerbase }} exaworks/sdk-base:latest
         docker push exaworks/sdk-base:latest
+        docker tag exaworks/sdk:${{ matrix.dockerbase }} exaworks/sdk:latest
         docker push exaworks/sdk:latest

--- a/docker/base/scripts/install-mpi.sh
+++ b/docker/base/scripts/install-mpi.sh
@@ -27,7 +27,7 @@ if [[ "$1" == "openmpi-devel" ]]; then
         PATCH=7
         CONFIGURE_ARGS="--with-pmi --with-pmi-libdir=/usr/lib64"
     elif [[ $(centos_major_version) == "8" ]]; then
-        yum_install_only_deps $1
+        yum_install_only_deps "openmpi"
         MAJOR_MINOR=4.0
         PATCH=6
         CONFIGURE_ARGS=""

--- a/docker/base/scripts/install-mpi.sh
+++ b/docker/base/scripts/install-mpi.sh
@@ -16,7 +16,8 @@ yum_install_only_deps () {
         echo "Package required for installing deps" 1>&2
         exit 1
     fi
-    yum deplist $1 | grep provider | awk '{print $2}' | sort | uniq | grep -v $PACKAGE | sed ':a;N;$!ba;s/\n/ /g' | xargs yum -y install
+    PACKAGE="$1"
+    yum deplist $PACKAGE | grep provider | awk '{print $2}' | sort | uniq | grep -v $PACKAGE | sed ':a;N;$!ba;s/\n/ /g' | xargs yum -y install
 }
 
 if [[ "$1" == "openmpi-devel" ]]; then


### PR DESCRIPTION
It is hard to test the `deploy` action since it only runs after a PR merge. So a failure occurred with a message:

```
Run docker push exaworks/sdk-base:latest
The push refers to repository [docker.io/exaworks/sdk-base]
tag does not exist: exaworks/sdk-base:latest
Error: Process completed with exit code 1.
```

This includes a fix for that error by tagging the already built centos7 images with the `latest` tag before pushing.

Also includes a fix for some error messages that I was seeing in the building of the centos8 image in CI