### PR TITLE
base: introduced docker file for Ubuntu 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        dockerbase: ["centos7", "centos8"]
+        dockerbase: ["centos7", "centos8", "ubuntu2004"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dockerbase: ["centos7", "centos8"]
+        dockerbase: ["centos7", "centos8", "ubuntu2004"]
 
     steps:
     - name: Checkout repo

--- a/docker/base/scripts/install-python.sh
+++ b/docker/base/scripts/install-python.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -ex
+
+if [[ -z $1 ]]; then
+    echo "Must provide python version (e.g., 3.6) to be installed" 1>&2
+    exit 1
+fi
+
+# all dependencies should be resolved in base Dockerfile (including: openssl xz gdbm)
+# yum-based systems
+#    yum -y install yum-utils
+#    yum-builddep -y python3
+# dnf-based systems
+#    dnf -y install dnf-plugins-core
+#    dnf builddep -y python3
+# apt-based systems
+#    apt-get -y install build-essential gdb lcov libbz2-dev libffi-dev libgdbm-dev \
+#               liblzma-dev libncurses5-dev libreadline6-dev libsqlite3-dev \
+#               libssl-dev lzma lzma-dev tk-dev uuid-dev zlib1g-dev
+
+PY_BASE_VER="$1"
+
+case "$PY_BASE_VER" in
+    "3.6")
+        PY_VER="3.6.15"
+        ;;
+    "3.7")
+        PY_VER="3.7.12"
+        ;;
+    "3.8")
+        PY_VER="3.8.12"
+        ;;
+    "3.9")
+        PY_VER="3.9.7"
+        ;;
+    *)
+        echo "Provided version is not supported" 1>&2
+        exit 1
+esac
+
+PY_NAME="Python-$PY_VER"
+PY_TARBALL="$PY_NAME.tgz"
+PY_PREFIX="/usr"
+
+cd /tmp
+wget -q --no-check-certificate "https://www.python.org/ftp/python/$PY_VER/$PY_TARBALL"
+tar xzf "$PY_TARBALL"
+cd "/tmp/$PY_NAME"
+./configure --enable-shared --prefix="$PY_PREFIX" && make && make install
+
+if [[ ! "$PY_PREFIX" == "/usr" ]]; then
+    ln -sf "$PY_PREFIX/bin/python$PY_BASE_VER" "/usr/bin/python3"
+    ln -sf "$PY_PREFIX/bin/python$PY_BASE_VER" "/usr/bin/python$PY_BASE_VER"
+fi
+
+cd / && rm "/tmp/$PY_TARBALL" && rm -r "/tmp/$PY_NAME"

--- a/docker/base/ubuntu2004/Dockerfile
+++ b/docker/base/ubuntu2004/Dockerfile
@@ -91,5 +91,5 @@ RUN wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.15-bin.tar.
  && ln -s /opt/apache-ant-1.9.15 /opt/ant \
  && sudo ln -s /opt/ant/bin/ant /usr/bin/ant
 
-# COPY ./scripts/install-mpi.sh /install-mpi.sh
-# RUN bash install-mpi.sh ${MPI}
+COPY ./scripts/install-mpi.sh /install-mpi.sh
+RUN bash install-mpi.sh ${MPI}

--- a/docker/base/ubuntu2004/Dockerfile
+++ b/docker/base/ubuntu2004/Dockerfile
@@ -2,58 +2,35 @@ FROM ubuntu:20.04
 
 ARG MPI=openmpi-devel
 ARG MPI_PREFIX=/usr/local/
-ARG PYTHON_VERSION=3.6
 ENV VIRTUAL_ENV=/ve_exaworks
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV MPI_PREFIX=${MPI_PREFIX}
 ENV MPICC=$MPI_PREFIX/bin/mpicc
 
-# MongoDB installation (RADICAL-Pilot Dependency)
+# General Dependencies
 RUN apt-get update -y \
- && apt install -y curl gnupg \
- && curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
+ && apt install -y \
+    cppcheck \
+    curl \
+    file \
+    gcc \
+    git \
+    gnupg \
+    man-db \
+    munge \
+    libmunge-dev \
+    libsodium-dev \
+    sudo \
+    wget
+
+# MongoDB installation (RADICAL-Pilot Dependency)
+RUN curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
  && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | \
     tee /etc/apt/sources.list.d/mongodb-org-4.4.list \
  && apt-get update -y \
  && ln -T /bin/true /usr/bin/systemctl \
  && DEBIAN_FRONTEND=noninteractive apt install -y mongodb-org \
  && rm /usr/bin/systemctl
-
-# Pre-python setup
-RUN apt-get update -y \
- && apt install -y \
-    # General & Python dependency \
-#    cppcheck \
-    file \
-    gcc \
-    git \
-    man-db \
-    munge \
-    libmunge-dev \
-    libsodium-dev \
-    sudo \
-    wget \
-    # Python Dependencies
-    build-essential \
-    gdb \
-    lcov \
-    libbz2-dev \
-    libffi-dev \
-    libgdbm-dev \
-    liblzma-dev \
-    libncurses5-dev \
-    libreadline6-dev \
-    libsqlite3-dev \
-    libssl-dev \
-    lzma \
-    lzma-dev  \
-    tk-dev  \
-    uuid-dev \
-    zlib1g-dev
-
-# Python installation
-COPY ./scripts/install-python.sh /install-python.sh
-RUN bash install-python.sh ${PYTHON_VERSION}
 
 RUN apt-get update -y \
  && apt install -y \
@@ -73,13 +50,13 @@ RUN apt-get update -y \
     lua5.1 \
     liblua5.1-dev \
     lua-posix \
-#    python3-dev \
-#    python3-cffi \
-#    python3-yaml \
-#    python3-jsonschema \
-#    python3-sphinx \
-#    python3-pip \
-#    python3-venv \
+    python3-dev \
+    python3-cffi \
+    python3-yaml \
+    python3-jsonschema \
+    python3-sphinx \
+    python3-pip \
+    python3-venv \
     aspell \
     aspell-en \
     valgrind \
@@ -101,7 +78,7 @@ RUN apt-get update -y \
     zsh \
  && apt-get clean \
     # VE setup with pip packages
- && python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV} \
+ && python3 -m venv ${VIRTUAL_ENV} \
  && pip install --upgrade pip setuptools pytest \
     # Flux python deps
  && pip install cffi six pyyaml jsonschema \

--- a/docker/base/ubuntu2004/Dockerfile
+++ b/docker/base/ubuntu2004/Dockerfile
@@ -1,0 +1,91 @@
+FROM ubuntu:20.04
+
+ARG MPI=openmpi-devel
+ARG MPI_PREFIX=/usr/local/
+ENV VIRTUAL_ENV=/ve_exaworks
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV MPI_PREFIX=${MPI_PREFIX}
+ENV MPICC=$MPI_PREFIX/bin/mpicc
+
+# MongoDB install (RADICAL-Pilot Dependency)
+RUN apt-get update -y \
+ && apt install -y curl gnupg \
+ && curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
+ && echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 multiverse" | \
+    tee /etc/apt/sources.list.d/mongodb-org-4.4.list \
+ && apt-get update -y \
+ && ln -T /bin/true /usr/bin/systemctl \
+ && DEBIAN_FRONTEND=noninteractive apt install -y mongodb-org \
+ && rm /usr/bin/systemctl
+
+RUN apt-get update -y \
+ && apt install -y \
+    # General & Flux-core Dependencies
+    cppcheck \
+    file \
+    gcc \
+    git \
+    man-db \
+    munge \
+    libmunge-dev \
+    libsodium-dev \
+    sudo \
+    wget \
+    autoconf \
+    automake \
+    libtool \
+    make \
+    pkg-config  \
+    libzmq3-dev  \
+    libczmq-dev \
+    uuid-dev \
+    libjansson-dev \
+    liblz4-dev \
+    libhwloc-dev \
+    libsqlite3-dev \
+    lua5.1 \
+    liblua5.1-dev \
+    lua-posix \
+    python3-dev \
+    python3-cffi \
+    python3-yaml \
+    python3-jsonschema \
+    python3-sphinx \
+    python3-pip \
+    python3-venv \
+    aspell \
+    aspell-en \
+    valgrind \
+    libmpich-dev \
+    jq \
+    # Flux-sched Dependencies
+    libboost-dev \
+    libboost-system-dev \
+    libboost-filesystem-dev \
+    libboost-graph-dev \
+    libboost-regex-dev \
+    libedit-dev \
+    libxml2-dev \
+    libyaml-cpp-dev \
+    # Swift/T Dependencies
+    openjdk-8-jdk-headless \
+    tcl-dev \
+    swig \
+    zsh \
+    # VE setup with pip packages
+ && apt-get clean \
+ && python3 -m venv ${VIRTUAL_ENV} \
+ && pip install --upgrade pip setuptools pytest \
+    # Flux python deps
+ && pip install cffi six pyyaml jsonschema \
+    # Parsl python deps
+ && pip install "cryptography==3.3.2"
+
+# Swift/T Dependency on Apache Ant
+RUN wget https://archive.apache.org/dist/ant/binaries/apache-ant-1.9.15-bin.tar.gz \
+ && tar xvf apache-ant-1.9.15-bin.tar.gz -C /opt \
+ && ln -s /opt/apache-ant-1.9.15 /opt/ant \
+ && sudo ln -s /opt/ant/bin/ant /usr/bin/ant
+
+# COPY ./scripts/install-mpi.sh /install-mpi.sh
+# RUN bash install-mpi.sh ${MPI}

--- a/docker/base/ubuntu2004/Dockerfile
+++ b/docker/base/ubuntu2004/Dockerfile
@@ -2,12 +2,13 @@ FROM ubuntu:20.04
 
 ARG MPI=openmpi-devel
 ARG MPI_PREFIX=/usr/local/
+ARG PYTHON_VERSION=3.6
 ENV VIRTUAL_ENV=/ve_exaworks
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV MPI_PREFIX=${MPI_PREFIX}
 ENV MPICC=$MPI_PREFIX/bin/mpicc
 
-# MongoDB install (RADICAL-Pilot Dependency)
+# MongoDB installation (RADICAL-Pilot Dependency)
 RUN apt-get update -y \
  && apt install -y curl gnupg \
  && curl -fsSL https://www.mongodb.org/static/pgp/server-4.4.asc | apt-key add - \
@@ -18,10 +19,11 @@ RUN apt-get update -y \
  && DEBIAN_FRONTEND=noninteractive apt install -y mongodb-org \
  && rm /usr/bin/systemctl
 
+# Pre-python setup
 RUN apt-get update -y \
  && apt install -y \
-    # General & Flux-core Dependencies
-    cppcheck \
+    # General & Python dependency \
+#    cppcheck \
     file \
     gcc \
     git \
@@ -31,6 +33,31 @@ RUN apt-get update -y \
     libsodium-dev \
     sudo \
     wget \
+    # Python Dependencies
+    build-essential \
+    gdb \
+    lcov \
+    libbz2-dev \
+    libffi-dev \
+    libgdbm-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libreadline6-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    lzma \
+    lzma-dev  \
+    tk-dev  \
+    uuid-dev \
+    zlib1g-dev
+
+# Python installation
+COPY ./scripts/install-python.sh /install-python.sh
+RUN bash install-python.sh ${PYTHON_VERSION}
+
+RUN apt-get update -y \
+ && apt install -y \
+    # Flux-core Dependencies
     autoconf \
     automake \
     libtool \
@@ -46,13 +73,13 @@ RUN apt-get update -y \
     lua5.1 \
     liblua5.1-dev \
     lua-posix \
-    python3-dev \
-    python3-cffi \
-    python3-yaml \
-    python3-jsonschema \
-    python3-sphinx \
-    python3-pip \
-    python3-venv \
+#    python3-dev \
+#    python3-cffi \
+#    python3-yaml \
+#    python3-jsonschema \
+#    python3-sphinx \
+#    python3-pip \
+#    python3-venv \
     aspell \
     aspell-en \
     valgrind \
@@ -72,9 +99,9 @@ RUN apt-get update -y \
     tcl-dev \
     swig \
     zsh \
-    # VE setup with pip packages
  && apt-get clean \
- && python3 -m venv ${VIRTUAL_ENV} \
+    # VE setup with pip packages
+ && python${PYTHON_VERSION} -m venv ${VIRTUAL_ENV} \
  && pip install --upgrade pip setuptools pytest \
     # Flux python deps
  && pip install cffi six pyyaml jsonschema \

--- a/docker/rp/run_rp_test.sh
+++ b/docker/rp/run_rp_test.sh
@@ -2,7 +2,7 @@
 
 # run mongodb, let it settle
 echo '--- start MongoDB'
-mongod --fork --logpath /tmp/mongodb.log
+mongod --fork --logpath /tmp/mongodb.log --config /etc/mongod.conf
 
 cd radical.pilot
 echo '--- smoke test'

--- a/docker/swift-t/install-deps.sh
+++ b/docker/swift-t/install-deps.sh
@@ -4,7 +4,7 @@ set -eux
 # INSTALL DEPENDENCIES
 # Currently just Tcl
 
-if which tclsh8.6 >& /dev/null
+if which tclsh8.6 > /dev/null 2>&1
 then
   # Tcl is installed, probably via package manager.
   # Note that this does not check for tcl-devel,

--- a/docker/swift-t/install-swift-t.sh
+++ b/docker/swift-t/install-swift-t.sh
@@ -13,8 +13,7 @@ PATH=/opt/tcl-8.6.11/bin:$PATH
 git clone https://github.com/swift-lang/swift-t.git
 
 # Build it
-pushd swift-t/dev/build
+cd swift-t/dev/build
 cp -v swift-t-settings.sh.template swift-t-settings.sh
 sed -i "/SWIFT_T_PREFIX=/s@=.*@=$SWIFT_ROOT@" swift-t-settings.sh
 ./build-swift-t.sh
-popd


### PR DESCRIPTION
Issues to resolve:
- [x] ~python of version 3.6 (for Ubuntu 20.04, the default version is 3.8)~
   - edited on 09/17: keep this for future PR (see ticket [#74](https://github.com/ExaWorks/SDK/issues/74))
- [x] use default python package
- [x] errors while building image for swift/t
```
=> ERROR [5/8] RUN ./install-deps.sh                                                                                                                                                                                                                              0.2s
------                                                                                                                                                                                                                                                                  
 > [5/8] RUN ./install-deps.sh:
#9 0.225 ./install-deps.sh: 14: Syntax error: Bad fd number
------
executor failed running [/bin/sh -c ./install-deps.sh]: exit code: 2
```
- [x] OpenMPI installation (script `install-mpi.sh` used for CentOS7/8 is commented out)
