### PR TITLE
Add in bare metal tests for Gitlab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -125,7 +125,7 @@ Spack Test:
   stage: test
   parallel:
       matrix:
-        - TEST : ["rp", "swift-t", "parsl", "flux"]
+        - TEST : ["rp", "swift-t", "parsl", "flux", "rp-flux", "parsl-flux"]
   before_script:
     - whoami
   tags:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -110,17 +110,14 @@ Container Test:
 
 Spack Build:
   stage: build
-  before_script:
-    - whoami
-    - mkdir /usr/workspace/morton30/spack/
   tags:
     - quartz
     - shell
   needs: []
   script:
-    - cd /usr/workspace/morton30/spack/
+    - cd $SPACK_WORK_DIR/
     - git clone -c feature.manyFiles=true https://github.com/spack/spack.git
-    - . /usr/workspace/morton30/spack/spack/share/spack/setup-env.sh
+    - . $SPACK_WORK_DIR/spack/share/spack/setup-env.sh
     - spack install exaworks
     - spack install py-pytest
 
@@ -136,7 +133,7 @@ Spack Test:
     - batch
   needs: [Spack Build]
   script:
-    - . /usr/workspace/morton30/spack/spack/share/spack/setup-env.sh
+    - . $SPACK_WORK_DIR/spack/share/spack/setup-env.sh
     - spack load exaworks py-pytest
     - export RADICAL_PILOT_DBURL=${MONGODB_CONNECTION_STRING}?tlsAllowInvalidCertificates=true
     - bash ci/tests/${TEST}/test.sh
@@ -152,4 +149,4 @@ Spack Clean:
     - shell
   needs: [Spack Test]
   script:
-    - rm -rf /usr/workspace/morton30/spack/
+    - rm -rf $SPACK_WORK_DIR/spack/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,12 +5,12 @@ variables:
   QUAY_LATEST: "latest"
 
 stages:
-  - build_base
-  - build_core
+  - build
   - test
+  - clean
 
-build_base_image:
-  stage: build_base
+Build Base Image:
+  stage: build
   parallel:
     matrix:
       - BASE: ["centos7", "centos8", "ubuntu"]
@@ -21,6 +21,7 @@ build_base_image:
   tags:
     - quartz
     - batch
+  needs: []
   script:
     - >
         for i in $(seq 1 $CI_NODE_TOTAL); do
@@ -41,8 +42,8 @@ build_base_image:
         s=$? && sleep 5; done; (exit $s)
     - podman logout $QUAY_HOST
 
-build_core_image:
-  stage: build_core
+Build Core Image:
+  stage: build
   parallel:
     matrix:
       - BASE: ["centos7", "centos8", "ubuntu"]
@@ -54,6 +55,7 @@ build_core_image:
   tags:
     - quartz
     - batch
+  needs: [Build Base Image]
   script:
     - export base_tag=${QUAY_HOST}${QUAY_ORG}base-${BASE}-${MPI}:$QUAY_LATEST
     - export tag=${QUAY_HOST}${QUAY_ORG}${CORE}-${BASE}-${MPI}:${QUAY_LATEST}
@@ -76,7 +78,7 @@ build_core_image:
     - podman logout $QUAY_HOST
 
 
-test_image:
+Container Test:
   stage: test
   parallel:
     matrix:
@@ -89,6 +91,7 @@ test_image:
   tags:
     - quartz
     - batch
+  needs: [Build Core Image]
   script:
     - export tag=${QUAY_HOST}${QUAY_ORG}${CORE}-${BASE}-${MPI}:${QUAY_LATEST}
     - >
@@ -104,3 +107,49 @@ test_image:
 
     - podman run $tag
     - podman logout $QUAY_HOST
+
+Spack Build:
+  stage: build
+  before_script:
+    - whoami
+    - mkdir /usr/workspace/morton30/spack/
+  tags:
+    - quartz
+    - shell
+  needs: []
+  script:
+    - cd /usr/workspace/morton30/spack/
+    - git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+    - . /usr/workspace/morton30/spack/spack/share/spack/setup-env.sh
+    - spack install exaworks
+    - spack install py-pytest
+
+Spack Test:
+  stage: test
+  parallel:
+      matrix:
+        - TEST : ["rp", "swift-t", "parsl", "flux"]
+  before_script:
+    - whoami
+  tags:
+    - quartz
+    - batch
+  needs: [Spack Build]
+  script:
+    - . /usr/workspace/morton30/spack/spack/share/spack/setup-env.sh
+    - spack load exaworks py-pytest
+    - export RADICAL_PILOT_DBURL=${MONGODB_CONNECTION_STRING}?tlsAllowInvalidCertificates=true
+    - bash ci/tests/${TEST}/test.sh
+  after_script:
+    - whoami
+
+Spack Clean:
+  stage: clean
+  before_script:
+    - whoami
+  tags:
+    - quartz
+    - shell
+  needs: [Spack Test]
+  script:
+    - rm -rf /usr/workspace/morton30/spack/

--- a/ci/config/llnl/config.yaml
+++ b/ci/config/llnl/config.yaml
@@ -1,0 +1,59 @@
+config:
+  template_dirs:
+  - $spack/share/spack/templates
+
+  # Temporary locations Spack can try to use for builds.
+  #
+  # Recommended options are given below.
+  #
+  # Builds can be faster in temporary directories on some (e.g., HPC) systems.
+  # Specifying `$tempdir` will ensure use of the default temporary directory
+  # (i.e., ``$TMP` or ``$TMPDIR``).
+  #
+  # Another option that prevents conflicts and potential permission issues is
+  # to specify `$user_cache_path/stage`, which ensures each user builds in their
+  # home directory.
+  #
+  # A more traditional path uses the value of `$spack/var/spack/stage`, which
+  # builds directly inside Spack's instance without staging them in a
+  # temporary space.  Problems with specifying a path inside a Spack instance
+  # are that it precludes its use as a system package and its ability to be
+  # pip installable.
+  #
+  # In any case, if the username is not already in the path, Spack will append
+  # the value of `$user` in an attempt to avoid potential conflicts between
+  # users in shared temporary spaces.
+  #
+  # The build stage can be purged with `spack clean --stage` and
+  # `spack clean -a`, so it is important that the specified directory uniquely
+  # identifies Spack staging to avoid accidentally wiping out non-Spack work.
+  build_stage:
+  - $tempdir/$user/spack-stage
+  - $user_cache_path/stage
+  # - $spack/var/spack/stage
+
+  # Directory in which to run tests and store test results.
+  # Tests will be stored in directories named by date/time and package
+  # name/hash.
+  test_stage: $user_cache_path/test
+  source_cache: $spack/var/spack/cache
+  misc_cache: $user_cache_path/cache
+  connect_timeout: 10
+  verify_ssl: true
+  suppress_gpg_warnings: false
+  install_missing_compilers: false
+  checksum: true
+  deprecated: false
+  dirty: false
+  build_language: C
+  locks: true
+  url_fetch_method: curl
+  ccache: false
+  concretizer: clingo
+  db_lock_timeout: 3
+  package_lock_timeout: null
+  shared_linking: rpath
+  allow_sgid: true
+  terminal_title: false
+  debug: false
+  build_jobs: 16

--- a/ci/config/llnl/packages.yaml
+++ b/ci/config/llnl/packages.yaml
@@ -1,0 +1,60 @@
+packages:
+  bzip2:
+    externals:
+    - spec: bzip2@1.0.6
+      prefix: /usr
+  gcc:
+    externals:
+    - spec: gcc@4.8.5 languages=c,c++,fortran
+      prefix: /usr
+      extra_attributes:
+        compilers:
+          c: /usr/bin/x86_64-redhat-linux-gcc
+          cxx: /usr/bin/g++
+          fortran: /usr/bin/gfortran
+    - spec: gcc@4.9.3 languages=c,c++,fortran
+      prefix: /usr/tce
+      extra_attributes:
+        compilers:
+          c: /usr/tce/bin/gcc
+          cxx: /usr/tce/bin/g++
+          fortran: /usr/tce/bin/gfortran
+  git:
+    externals:
+    - spec: git@1.8.3.1+tcltk
+      prefix: /usr
+    - spec: git@2.29.1+tcltk
+      prefix: /usr/tce
+  git-lfs:
+    externals:
+    - spec: git-lfs@2.12.0
+      prefix: /usr/tce
+  libtool:
+    externals:
+    - spec: libtool@2.4.2
+      prefix: /usr
+  m4:
+    externals:
+    - spec: m4@1.4.16
+      prefix: /usr
+  mvapich2:
+    externals:
+    - spec: mvapich2@2.3.1%intel@19.0.4.227~cuda~debug~regcache~wrapperrpath ch3_rank_bits=32
+        fabrics=mrail file_systems=lustre,nfs,ufs process_managers=slurm
+      prefix: /usr/tce/packages/mvapich2/mvapich2-2.3-intel-19.0.4
+  openssh:
+    externals:
+    - spec: openssh@7.4p1
+      prefix: /usr
+  pkg-config:
+    externals:
+    - spec: pkg-config@0.27.1
+      prefix: /usr
+  tar:
+    externals:
+    - spec: tar@1.26
+      prefix: /usr
+  xz:
+    externals:
+    - spec: xz@5.2.2
+      prefix: /usr

--- a/ci/tests/flux/test.sh
+++ b/ci/tests/flux/test.sh
@@ -1,0 +1,6 @@
+output=$(flux start flux mini run echo Success)
+if [[ "$output" != "Success" ]]; then
+    exit 1
+fi
+
+echo "Success!"

--- a/ci/tests/parsl-flux/test.sh
+++ b/ci/tests/parsl-flux/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+flux start python3 -m pytest $(python3 -c \
+	"import parsl.tests.test_flux as tf; print(tf.__file__)") \
+	--config=local --tap-stream

--- a/ci/tests/parsl/test.py
+++ b/ci/tests/parsl/test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+import parsl
+import os
+from parsl.app.app import python_app, bash_app
+from parsl.configs.local_threads import config
+
+parsl.load(config)
+
+@python_app
+def hello ():
+    return 'Hello World from Python!'
+
+print(hello().result())
+
+@bash_app
+def echo_hello(stdout='/tmp/echo-hello.stdout', stderr='/tmp/echo-hello.stderr'):
+    return 'echo "Hello World!"'
+
+echo_hello().result()
+
+with open('/tmp/echo-hello.stdout', 'r') as f:
+    print(f.read())

--- a/ci/tests/parsl/test.sh
+++ b/ci/tests/parsl/test.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+python ci/tests/parsl/test.py | tee /tmp/test-output
+
+cat <<EOF >/tmp/expected-output
+Hello World from Python!
+Hello World!
+
+EOF
+
+if diff /tmp/test-output /tmp/expected-output; then
+	echo "Output matches"
+else
+	echo "Output does not match"
+	exit 1
+fi
+
+echo "Success!"

--- a/ci/tests/rp-flux/resource_flux.json
+++ b/ci/tests/rp-flux/resource_flux.json
@@ -1,0 +1,12 @@
+{
+    "localhost_flux": {
+        "pre_bootstrap_0"             : [],
+        "pre_bootstrap_1"             : [],
+        "virtenv_mode"                : "local",
+        "agent_scheduler"             : "FLUX",
+        "agent_spawner"               : "FLUX",
+        "agent_launch_method"         : "FORK",
+        "task_launch_method"          : "FLUX",
+        "mpi_launch_method"           : "FLUX"
+    }
+}

--- a/ci/tests/rp-flux/test.sh
+++ b/ci/tests/rp-flux/test.sh
@@ -1,0 +1,12 @@
+git clone -b master --single-branch https://github.com/radical-cybertools/radical.pilot.git
+
+mkdir -p ~/.radical/pilot/configs/
+cp resource_flux.json ~/.radical/pilot/configs/resource_flux.json
+
+cd radical.pilot
+echo '--- smoke test'
+./examples/00_getting_started.py flux.localhost_flux
+ret=$?
+echo "--- smoke test $ret"
+
+exit $ret

--- a/ci/tests/rp/test.sh
+++ b/ci/tests/rp/test.sh
@@ -1,0 +1,21 @@
+git clone -b master --single-branch https://github.com/radical-cybertools/radical.pilot.git
+
+cd radical.pilot
+echo '--- smoke test'
+./examples/00_getting_started.py
+ret=$?
+echo "--- smoke test $ret"
+
+echo '--- unit test'
+pytest -vvv tests/unit_tests
+test "$ret" = 0 && ret=$?
+echo "--- unit test $ret"
+
+echo '--- component test'
+pytest -vvv tests/component_tests
+test "$ret" = 0 && ret=$?
+echo "--- component test $ret"
+
+echo "Success!"
+
+exit $ret

--- a/ci/tests/swift-t/test.sh
+++ b/ci/tests/swift-t/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eux
+
+# SWIFT/T TEST SANITY
+# Simply sanity tests for fresh Docker build
+
+# For OpenMPI
+export TURBINE_LAUNCH_OPTIONS=--allow-run-as-root
+
+swift-t -v
+swift-t -E 'trace(42);'
+
+echo "Success!"


### PR DESCRIPTION
This PR adds in bare metal CI tests for gitlab. These tests utilize Spack to build the SDK and come in the form of 3 new jobs added into the CI pipeline. 

The first stage uses Spack to build the SDK. This build process is aided with a couple configuration files. `config.yaml` is essentially a copy of the default Spack configuration except that the field for `url_fetch_method` is set to `curl` instead of the default of `urllib`. This change was made because the default option seemed to result in some intermittent timeout failures when tested on LLNL machines. `packages.yaml` contains information on some of the SDK dependencies and where they can already be found on the machine running the build. This configuration will likely be site or machine specific. In this PR both configuration files have been added to the `ci/llnl/` directory for they may both be site specific. Currently neither configuration file is actively used, but represents a template for what may exist in `~/.spack/`. 

The second stage uses the previously built Spack environment to run smoke tests on each of the 4 packages. The tests are run by calling `ci/tests/<package name>/test.sh`. These simple smoke tests can be improved upon and added to in future PRs. Additionally, integration tests can be added as well by adding an addition directory `/ci/tests/<integration>/`. The RP tests use an on premise mongodb instance, which is connected to with an injected connection string variable.  

The third stage cleans and removes the Spack environment created from the first stage. 

