### PR TITLE
ci: updated mergify config away from deprecated 'strict' mode

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,11 +2,16 @@ queue_rules:
   - name: default
     conditions: &ci_checks
       # Conditions to get out of the queue (= merged)
-      - status-success="Run test suite (centos7, pip)"
-      - status-success="Run test suite (centos8, pip)"
-      - status-success="Run test suite (centos8, conda)"
-      - status-success="Run test suite (ubuntu2004, pip)"
-      - status-success="Run test suite (ubuntu2004, conda)"
+      - status-success="Run test suite (centos7, pip, openmpi)"
+      - status-success="Run test suite (centos7, pip, mpich)"
+      - status-success="Run test suite (centos8, pip, openmpi)"
+      - status-success="Run test suite (centos8, pip, mpich)"
+      - status-success="Run test suite (centos8, conda, openmpi)"
+      - status-success="Run test suite (centos8, conda, mpich)"
+      - status-success="Run test suite (ubuntu2004, pip, openmpi)"
+      - status-success="Run test suite (ubuntu2004, pip, mpich)"
+      - status-success="Run test suite (ubuntu2004, conda, openmpi)"
+      - status-success="Run test suite (ubuntu2004, conda, mpich)"
       - status-success="validate commits"
 
 pull_request_rules:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,20 +1,27 @@
-pull_request_rules:
-  - name: Automatic merge on approval
-    conditions:
-      - base=master
+queue_rules:
+  - name: default
+    conditions: &ci_checks
+      # Conditions to get out of the queue (= merged)
       - status-success="Run test suite (centos7, pip)"
       - status-success="Run test suite (centos8, pip)"
       - status-success="Run test suite (centos8, conda)"
       - status-success="Run test suite (ubuntu2004, pip)"
       - status-success="Run test suite (ubuntu2004, conda)"
       - status-success="validate commits"
+
+pull_request_rules:
+  - name: Automatic merge on approval
+    conditions:
+    # Conditions to get into the queue (= queued for merge)
+      - and: *ci_checks
+      - base=master
       - label="merge-when-passing"
       - label!="work-in-progress"
       - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
       - -title~=^\[*[Ww][Ii][Pp]
     actions:
-      merge:
+      queue:
         method: rebase
         rebase_fallback: merge
-        strict: smart+fasttrack
+        name: default


### PR DESCRIPTION
This PR seeks to fix the configuration for mergify. According to [this post ](https://blog.mergify.com/strict-mode-deprecation/), strict mode for mergify is now deprecated, and there is a new way to go about queuing merge requests. This PR follows most of the recommendations from the blog post. In addition, because our test matrix is large and growing, it made sense to make use of anchors so as not to repeat the list of CI tests under both the queue_rules and pull_request_rules. Because using anchors and aliases can be a bit tricky with arrays, I used the `and` operator as described [here](https://docs.mergify.com/conditions/#combining-conditions-with-operators). 