### PR TITLE
Upload ci results to testing dashboard

### DIFF
--- a/.github/test.py
+++ b/.github/test.py
@@ -1,0 +1,118 @@
+import argparse
+import requests
+from datetime import datetime
+import random
+import pprint
+import subprocess
+import sys
+import os
+
+tag = os.getenv("tag").split("_")
+run_id = os.getenv("run_id")
+branch = os.getenv("branch")
+url = 'https://sdk.testing.exaworks.org/result'
+
+config = { "maintainer_email" : "morton30@llnl.gov", "repo":"sdk"}
+
+extras = { "config" : config,
+           "Base Image": tag[0],
+           "Package Manager": tag[1],
+           "MPI Flavor": tag[2],
+           "Python Version": tag[3],
+           "git_branch" : branch,
+           "start_time" : str(datetime.now())
+         }
+
+
+data = { "run_id" : run_id,
+         "branch": branch,
+        }
+
+def get_conf():
+    results = {}
+    data.update( {"test_name" : "Set Environment",
+                  "results" : results,
+                  "extras": extras,
+                  "test_start_time": str(datetime.now()),
+                  "test_end_time" : str(datetime.now()),
+                  'function' : '_discover_environment',
+                  "module" : '_conftest' })
+    return data
+
+
+def get_result(command, name):
+    if not name:
+        name = command.split()[0]
+    start = str(datetime.now())
+
+    try:
+        out = subprocess.check_output(command, shell=True, stderr=subprocess.STDOUT).decode("utf-8")
+        ret = True
+    except subprocess.CalledProcessError as exc:
+        out = exc.output.decode("utf-8")
+        ret = False
+
+    end = str(datetime.now())
+    results = { name:
+                       {"passed" : ret},
+              }
+    data.update({ "test_name" : name,
+                  "results" : results,
+                  "test_start_time": start,
+                  "test_end_time" : end,
+                  "extras": {},
+                  "function" : name,
+                  "module" : "Sanity Checks",
+                  "stdout" : out
+            })
+    return data, ret
+
+def get_end():
+    results = {}
+    data.update( {"test_name" : "Set Environment",
+                  "results" : results,
+                  "extras": extras,
+                  "test_start_time": str(datetime.now()),
+                  "test_end_time" : str(datetime.now()),
+                  'function' : '_discover_environment',
+                  "module" : '_end' })
+
+    return data
+
+def get_args():
+    parser = argparse.ArgumentParser(description='Runs SDK Tests by passing in shell commands')
+    parser.add_argument('-c', '--command', action='store', type=str, default=None,
+                        help='The command in which you want to test.')
+    parser.add_argument('-n', '--name', action='store', type=str, default=None,
+                        help='The name of the test.')
+    parser.add_argument('-s', '--start', action="store_true",  default=False,
+                        help='Start a series of test runs with the same id')
+    parser.add_argument('-e', '--end', action="store_true",  default=False,
+                        help='End a series of test runs with the same id')
+    args = parser.parse_args(sys.argv[1:])
+    return args
+
+def main():
+    args = get_args()
+
+    ret = True
+    if args.start:
+        data = get_conf()
+    elif args.end:
+        data = get_end()
+    elif args.command:
+        data, ret = get_result(args.command, args.name)
+    else:
+        print("No viable option called, Exiting")
+        exit(1)
+
+    msg = {"id" : "Github Actions", "key" : "42", "data" : data}
+    requests.post(url, json=msg)
+
+    if ret:
+        exit(0)
+    else:
+        exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,14 +65,20 @@ jobs:
     - name: Run tests (${{ env.DOCKER_TAG }})
       run: |
         total=0
+        export tag=${{ env.DOCKER_TAG }}
+        export run_id=$RANDOM
+        export branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+        python3 .github/test.py -s
         for core in flux parsl rp swift flux-parsl
         do
-          docker run exaworks_sdk:${{ env.DOCKER_TAG }} \
-            bash --login -c "/tests/$core/test.sh"
+          python3 .github/test.py -n $core -c \
+          "docker run exaworks_sdk:${{ env.DOCKER_TAG }} \
+            bash --login -c /tests/$core/test.sh"
           ret=$?
           echo "$core   : $ret"
           total=$(($total + $ret))
         done
+        python3 .github/test.py -e
         exit $total
 
   check-pr:


### PR DESCRIPTION
This PR includes changes that upload the testing results to the [sdk testing dashboard](https://sdk.testing.exaworks.org/). 

This functionality mainly exists in a new `test.py` file that is used as a wrapper script to run the tests and capture and upload the results to the testing dashboard. For the SDK, we are curating a limited scope of data in hopes that we can get approval to upload results from computing centers like LLNL. The limited scope includes information like build parameters, results, and the output from running the tests themselves. 

Currently the build of the docker containers does not send any results to the dashboard, should we include each build as a test as well? For example, a run in this case would be the entire SDK build, and the tests would be SDK component build. 

