### PR TITLE
CI: Add scheduled tests to workflow 

### DIFF
--- a/.github/test.py
+++ b/.github/test.py
@@ -65,7 +65,7 @@ def get_result(command, name):
                   "module" : "Sanity Checks",
                   "stdout" : out
             })
-    return data, ret
+    return data
 
 def get_end():
     results = {}
@@ -101,18 +101,13 @@ def main():
     elif args.end:
         data = get_end()
     elif args.command:
-        data, ret = get_result(args.command, args.name)
+        data = get_result(args.command, args.name)
     else:
         print("No viable option called, Exiting")
         exit(1)
 
     msg = {"id" : "Github Actions", "key" : "42", "data" : data}
     requests.post(url, json=msg)
-
-    if ret:
-        exit(0)
-    else:
-        exit(1)
 
 if __name__ == '__main__':
     main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,19 +66,14 @@ jobs:
       run: |
         total=0
         export tag=${{ env.DOCKER_TAG }}
-        export run_id=$RANDOM
-        export branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
-        python3 .github/test.py -s
         for core in flux parsl rp swift flux-parsl
         do
-          python3 .github/test.py -n $core -c \
-          "docker run exaworks_sdk:${{ env.DOCKER_TAG }} \
-            bash --login -c /tests/$core/test.sh"
+          docker run exaworks_sdk:${{ env.DOCKER_TAG }} \
+          bash --login -c /tests/$core/test.sh
           ret=$?
           echo "$core   : $ret"
           total=$(($total + $ret))
         done
-        python3 .github/test.py -e
         exit $total
 
   check-pr:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,9 +76,13 @@ jobs:
           --build-arg BASE_IMAGE=rp_parsl:${{ env.DOCKER_TAG }} \
           docker/swift-t
         docker build \
-          -t exaworks/sdk:${{ env.DOCKER_TAG }} \
+          -t rp_parsl_swift_flux:${{ env.DOCKER_TAG }} \
           --build-arg BASE_IMAGE=rp_parsl_swift:${{ env.DOCKER_TAG }} \
           docker/flux
+        docker build \
+          -t exaworks/sdk:${{ env.DOCKER_TAG }} \
+          --build-arg BASE_IMAGE=rp_parsl_swift_flux:${{ env.DOCKER_TAG }} \
+          docker/integration
         docker push exaworks/sdk:${{ env.DOCKER_TAG }}
 
     - name: Push images with 'latest' tag

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,8 +43,6 @@ jobs:
         do
           python3 .github/test.py -n $core -c \
           "docker run exaworks/sdk:${{ env.DOCKER_TAG }} \
-            bash --login -c /tests/$core/test.sh"
-          ret=$?
-          echo "$core   : $ret"
+           bash --login -c /tests/$core/test.sh"
         done
         python3 .github/test.py -e

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: Scheduled CI Test
+on:
+  schedule:
+    - cron: '0 20 * * *'
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerbase: ["centos7", "rockylinux8", "ubuntu2004"]
+        packagemanager: ["pip", "conda"]
+        mpi: ["openmpi", "mpich"]
+        pyversion: ["3.7", "3.8", "3.9"]
+        exclude:
+          - dockerbase: "centos7"
+            packagemanager: "conda"
+          - dockerbase: "ubuntu2004"
+            packagemanager: "conda"
+          - pyversion: "3.8"
+            packagemanager: "conda"
+          - pyversion: "3.9"
+            packagemanager: "conda"
+    env:
+      DOCKER_TAG: "${{ matrix.dockerbase }}_${{ matrix.packagemanager }}_${{ matrix.mpi }}_${{ matrix.pyversion }}"
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+
+    - name: Run tests (${{ env.DOCKER_TAG }})
+      run: |
+        export tag=${{ env.DOCKER_TAG }}
+        export run_id=$RANDOM
+        export branch=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
+        docker pull exaworks/sdk:${{ env.DOCKER_TAG }}
+        python3 .github/test.py -s
+        for core in flux parsl rp swift flux-parsl
+        do
+          python3 .github/test.py -n $core -c \
+          "docker run exaworks/sdk:${{ env.DOCKER_TAG }} \
+            bash --login -c /tests/$core/test.sh"
+          ret=$?
+          echo "$core   : $ret"
+        done
+        python3 .github/test.py -e


### PR DESCRIPTION
This PR introduces changes to add a scheduled CI workflow to run tests on all builds for SDK images. The schedule runs on a daily basis and uploads results to the SDK testing dashboard https://sdk.testing.exaworks.org/summary.html. Because the results are uploaded to the dashboard, failing tests do not trigger a failing pipeline and should not be interpreted as such. These tests test the images deployed on Docker Hub rather than building fresh containers from source.

Because we are using the containers from docker hub, it was identified that the docker hub containers are not built with the integration docker file, so the integration was added to the deployment pipeline. Because we now use the integration dockerfile as the last stage of the build, the default command of the SDK image is now `bash`.  

Because the scheduled CI tests populate data to the dashboard, it seems reasonable to not upload results from Merge Request pipeline, ci.yml. This makes sense since that pipeline may be run during development and could populate the dashboard with failings for development purposes. 

Addresses issues #120  #121  #66 