### PR TITLE
Build tutorials docker container for `linux/amd64`,`linux/arm64` platforms

### DIFF
--- a/docker/tutorials/Dockerfile
+++ b/docker/tutorials/Dockerfile
@@ -1,5 +1,6 @@
 
-FROM jupyter/minimal-notebook:python-3.9
+ARG BUILDPLATFORM=linux/amd64
+FROM --platform=${BUILDPLATFORM} jupyter/minimal-notebook:python-3.9
 
 ENV JUPYTER_ENABLE_LAB=yes
 

--- a/docker/tutorials/README.md
+++ b/docker/tutorials/README.md
@@ -12,6 +12,12 @@ Jupyter Docker images - https://github.com/jupyter/docker-stacks
 ./docker/tutorials/build.sh
 ```
 
+**NOTE**: for ARM platform, please, pull the image from the DockerHub directly
+
+```shell
+docker pull exaworks/sdk-tutorials
+```
+
 ## A. Run container image (base)
 
 ```shell

--- a/docker/tutorials/push-multi-platform.sh
+++ b/docker/tutorials/push-multi-platform.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SDK_BASE_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )/../../" &> /dev/null && pwd 2> /dev/null; )"
+
+# push to the DockerHub registry
+docker buildx build \
+    --output=type=registry \
+    --platform linux/amd64,linux/arm64 \
+    -t exaworks/sdk-tutorials \
+    -f "$SDK_BASE_DIR/docker/tutorials/Dockerfile" \
+    "$SDK_BASE_DIR/docs/source/tutorials/"

--- a/docker/tutorials/push-multi-platform.sh
+++ b/docker/tutorials/push-multi-platform.sh
@@ -3,6 +3,7 @@
 SDK_BASE_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )/../../" &> /dev/null && pwd 2> /dev/null; )"
 
 # push to the DockerHub registry
+docker buildx create --use --name sdk_builder
 docker buildx build \
     --output=type=registry \
     --platform linux/amd64,linux/arm64 \


### PR DESCRIPTION
Container building fails on ARM platform (e.g., mac M1/2) due to platform limitation of some packages, thus we use a specific platform to build the container and target multiple platforms (`linux/amd64`,`linux/arm64`)