### PR TITLE
tutorials: fixed environment

### DIFF
--- a/docker/tutorials/Dockerfile
+++ b/docker/tutorials/Dockerfile
@@ -1,32 +1,64 @@
 
-ARG BUILDPLATFORM=linux/amd64
-FROM --platform=${BUILDPLATFORM} jupyter/minimal-notebook:python-3.9
+ARG BUILD_PLATFORM=linux/amd64
+ARG PY_VER=3.9
+
+FROM --platform=${BUILD_PLATFORM} jupyter/minimal-notebook:python-${PY_VER}
 
 ENV JUPYTER_ENABLE_LAB=yes
 
 USER root
 
-RUN apt-get update -y && apt-get install -y bc curl gnupg
+RUN apt-get update -y \
+ && apt-get install -y bc curl gnupg
+
+# General jupyter deps
+
+RUN mamba install -y -n base -c conda-forge \
+    ipywidgets \
+    jupyterlab_widgets \
+    nb_conda_kernels \
+    nodejs \
+ && mamba clean -a -f -y \
+ && jupyter labextension install @jupyter-widgets/jupyterlab-manager \
+ && fix-permissions "${CONDA_DIR}" \
+ && fix-permissions "/home/${NB_USER}"
 
 USER ${NB_UID}
+
+# Config for nb_conda_kernels
+
+RUN printf '\n\
+{ \n\
+  "CondaKernelSpecManager": { \n\
+    "kernelspec_path": "--user" \n\
+  } \n\
+} \n\
+' > $(jupyter --config-dir)/jupyter_config.json \
+ && jupyter nbextension install --user --py widgetsnbextension
+
+# Tutorials
 
 WORKDIR /tutorials/
 COPY --chown=${NB_UID}:${NB_GID} ./ ./
 
 # Parsl
 
-RUN conda install -y \
-    ipywidgets matplotlib pandas qcelemental qcengine rdkit scikit-learn tqdm \
- && conda install -y -c conda-forge parsl
+RUN git clone -b main --single-branch https://github.com/ExaWorks/molecular-design-parsl-demo \
+    parsl/molecular-design-parsl-demo \
+ && cd parsl/molecular-design-parsl-demo \
+ && sed -i '1d' environment.yml \
+ && mamba env create -n parsl -f environment.yml \
+ && mamba update -y -n parsl \
+    jupyterlab_widgets \
+    ipywidgets
 
-RUN cd parsl \
- && git clone -b main --single-branch https://github.com/ExaWorks/molecular-design-parsl-demo \
- && pip install -e molecular-design-parsl-demo/
+# RADICAL-Pilot (RP) & RADICAL-EnTK (RE)
 
-# RADICAL-EnTK
+RUN mamba install -y -c conda-forge \
+    radical.pilot=1.20 \
+    radical.entk=1.20
 
-RUN conda install -y -c conda-forge radical.entk
+# Parsl-RP Integration usecase NWChem
 
-# RP-Parsl Integration usecase nwchem
-
-RUN conda install -c conda-forge nwchem
+RUN mamba install -y -c conda-forge \
+    nwchem

--- a/docker/tutorials/Dockerfile
+++ b/docker/tutorials/Dockerfile
@@ -45,8 +45,7 @@ COPY --chown=${NB_UID}:${NB_GID} ./ ./
 # Parsl
 
 RUN git clone -b main --single-branch https://github.com/ExaWorks/molecular-design-parsl-demo \
-    parsl/molecular-design-parsl-demo \
- && cd parsl/molecular-design-parsl-demo \
+ && cd molecular-design-parsl-demo \
  && sed -i '1d' environment.yml \
  && mamba env create -n parsl -f environment.yml \
  && mamba update -y -n parsl \

--- a/docker/tutorials/Dockerfile
+++ b/docker/tutorials/Dockerfile
@@ -1,8 +1,9 @@
 
-ARG BUILD_PLATFORM=linux/amd64
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG BUILDPLATFORM=linux/amd64
 ARG PY_VER=3.9
 
-FROM --platform=${BUILD_PLATFORM} jupyter/minimal-notebook:python-${PY_VER}
+FROM --platform=${BUILDPLATFORM} jupyter/minimal-notebook:python-${PY_VER}
 
 ENV JUPYTER_ENABLE_LAB=yes
 

--- a/docker/tutorials/README.md
+++ b/docker/tutorials/README.md
@@ -6,7 +6,8 @@ method B or C.
 
 ## Build container image
 
-Jupyter Docker images - https://github.com/jupyter/docker-stacks
+SDK Tutorials container is based on 
+[jupyter/minimal-notebook](https://github.com/jupyter/docker-stacks) image.
 
 ```shell
 ./docker/tutorials/build.sh
@@ -24,7 +25,26 @@ docker pull exaworks/sdk-tutorials
 docker run --rm -it -p 8888:8888 exaworks/sdk-tutorials
 ```
 
-## B. Run container image (with MongoDB and RabbitMQ services)
+## B. Run `docker-compose` (extended)
+
+It starts `sdk-tutorials` container with auxiliary services, such as MongoDB
+and RabbitMQ, which are used by the RADICAL-Cybertools components.
+
+```shell
+cd docker/tutorials
+
+docker compose up -d
+docker compose logs -f sdk-tutorials
+# stop containers
+#   docker compose stop
+# remove containers
+#   docker compose rm -f
+```
+
+## C. Run container image with MongoDB and RabbitMQ services manually
+
+These steps do the same as `docker-compose`, but all necessary commands are
+executed manually.
 
 Docker network to communicate with services:
 
@@ -69,17 +89,4 @@ Stop services after work is done:
 docker stop sdk-mongodb sdk-rabbitmq
 # stop and remove containers
 #   docker rm -f sdk-mongodb sdk-rabbitmq
-```
-
-## C. Run `docker-compose`
-
-```shell
-cd docker/tutorials
-
-docker compose up -d
-docker compose logs -f sdk-tutorials
-# stop containers
-#   docker compose stop
-# remove containers
-#   docker compose rm -f
 ```


### PR DESCRIPTION
Environment for Parsl got to be separated due to dependencies
Whenever notebook is started, user need to pick a kernel/environment, currently 2 envs are provided: `parsl` and `root` (which is a base conda env)

(*) was tested successfully with all tutorials (for Parsl only the first tutorial was tested)
(**) corresponding `sdk-tutorials` container image is pushed to [DockerHub](https://hub.docker.com/r/exaworks/sdk-tutorials/tags)