### PR TITLE
mergify: drop parameter `rebase_fallback`

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,5 +36,4 @@ pull_request_rules:
     actions:
       queue:
         method: rebase
-        rebase_fallback: merge
         name: default


### PR DESCRIPTION
`Mergify will always report errors in the future if a rebase merge is impossible`

based on this comment: https://github.com/ExaWorks/SDK/pull/173#issuecomment-1494539359