### PR TITLE
LLNL spack CI wipe

### DIFF
--- a/.gitlab/llnl-ci-spack.yml
+++ b/.gitlab/llnl-ci-spack.yml
@@ -196,5 +196,6 @@ spack_cleanup:
     - spack clean -a || true
     - rm -rf ${HOME}/.spack/cache
     - spack providers
+    - find ${SPACK_WORK_DIR} -maxdepth 0 -type d -ctime +5 | xargs rm -rf
     - *finalize
 


### PR DESCRIPTION
This is a small PR that will wipe the spack directory to rebuild spack from scratch every (for now) 5 days.