### PR TITLE
rp tests: slightly improve pilot sandbox cleanup robustness

### DIFF
--- a/ci/tests/rp-flux/test.sh
+++ b/ci/tests/rp-flux/test.sh
@@ -26,7 +26,7 @@ radical-stack
 ret=$?
 echo "--- smoke test $ret"
 
-SID=$(ls -rt | grep rp.session)
+SID=$(ls -rt | grep rp.session | tail -1)
 test -z "$SID" || rm -rf "$HOME/radical.pilot.sandbox/$SID"
 echo '--- cleaned pilot sandbox'
 

--- a/ci/tests/rp/test.sh
+++ b/ci/tests/rp/test.sh
@@ -32,7 +32,7 @@ radical-stack
 ret=$?
 echo "--- smoke test $ret"
 
-SID=$(ls -rt | grep rp.session)
+SID=$(ls -rt | grep rp.session | tail -1)
 test -z "$SID" || rm -rf "$HOME/radical.pilot.sandbox/$SID"
 echo '--- cleaned pilot sandbox'
 


### PR DESCRIPTION
to eliminate stuff like below when manually running tests, where >1 rp.session... dir accumulates:
```
...
--- smoke test 0
rm: cannot remove '/global/homes/c/cowan/radical.pilot.sandbox/rp.session.nid005974.cowan.019684.0000'$'\n''rp.session.nid005916.cowan.019684.0001'$'\n''rp.session.nid004876.cowan.019684.0002'$'\n''rp.session.nid200241.cowan.019690.0000'$'\n''rp.session.nid200241.cowan.019690.0001'$'\n''rp.session.nid200002.cowan.019690.0002'$'\n''rp.session.nid200002.cowan.019690.0003'$'\n''rp.session.nid200044.cowan.019
692.0000'$'\n''rp.session.nid200044.cowan.019692.0001'$'\n''rp.session.nid200023.cowan.019692.0002'$'\n''rp.session.nid200023.cowan.019692.0003': File name too long
--- cleaned pilot sandbox
Success!
...
```

still fragile, but slightly better...