### PR TITLE
LLNL CI Spack: added Ant fix for swift-t installation

### DIFF
--- a/.gitlab/README.md
+++ b/.gitlab/README.md
@@ -72,6 +72,17 @@ mkdir -p pre-stage
 spack stage -p pre-stage python
 ```
 
+### LLNL Machines not installing Swift-T
+
+When spack is installing Swift-T, it installs `ant` as a dependency.
+For an unknown reason, `ant` is unable to initialize the Java Virtual Machine,
+thus we're unable to install Swift-T. For now a [temporary solution](https://github.com/ExaWorks/SDK/blob/9c272ba2462298ff49e91e97f73fca029bd9c11b/.gitlab/llnl-ci-spack.yml#L55-L59) has been put in place.
+We chose to instruct Spack to use the available system install of `ant` instead of a Spack installation.
+
+Here is the related issue: [#174](https://github.com/ExaWorks/SDK/issues/174)
+
+The temporary solution can be improved upon once [Spack PR #40976](https://github.com/spack/spack/pull/40976) is merged into Spack
+
 ---
 
 ## References for GitLab-related services

--- a/.gitlab/llnl-ci-spack.yml
+++ b/.gitlab/llnl-ci-spack.yml
@@ -52,6 +52,11 @@ stages:
     - spack config add concretizer:unify:when_possible
     - spack config add concretizer:reuse:false
     - spack config add config:db_lock_timeout:300
+    - spack config add packages:ant:buildable:false
+    - spack config add packages:ant:externals:spec:ant@1.10.5
+    # - spack config add packages:ant:externals:prefix:"/usr" # FIXME/NOTE: uncomment once spack PR: https://github.com/spack/spack/pull/40976 is merged
+    - sed -i '/- spec: ant@1\.10\.5/ a \ \ \ \ \ \  \ prefix: /usr' \
+        $(find $(spack location -e ${SPACK_ENV_NAME}) -name spack.yaml -print -quit) # NOTE: This is a temporary fix until pr above is merged
     - module --latest load gcc && spack compiler find
     - spack add rust ^openssl certs=system
     - spack install || (spack env deactivate && spack env remove ${SPACK_ENV_NAME} -y && exit 1)


### PR DESCRIPTION
When installing Swift-T via `spack`, its spack installed `ant` dependency fails to initialize the Java VM. We're now instructing spack to use the ant installation already available on LLNL machines.